### PR TITLE
feat(restaurant-catalog, user): Implementar validación de propietario vía comunicación inter-servicio (Tarea 3.12)

### DIFF
--- a/microservice-restaurant-catalog/pom.xml
+++ b/microservice-restaurant-catalog/pom.xml
@@ -27,10 +27,7 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
-<<<<<<< HEAD
-=======
 		<spring-cloud.version>2024.0.1</spring-cloud.version>
->>>>>>> 10352e266cac05aa46b170167b17643ccc591305
 	</properties>
 	<dependencies>
 		<dependency>

--- a/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/MicroserviceRestaurantCatalogApplication.java
+++ b/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/MicroserviceRestaurantCatalogApplication.java
@@ -2,8 +2,10 @@ package com.mycompany.app.microservice_restaurant_catalog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class MicroserviceRestaurantCatalogApplication {
 
 	public static void main(String[] args) {

--- a/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/application/exception/ErrorMessagesApplication.java
+++ b/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/application/exception/ErrorMessagesApplication.java
@@ -4,7 +4,8 @@ public enum ErrorMessagesApplication {
 
 
     NIT_ALREADY_EXIST("The 'nit' field must be unique."),
-    NAME_ALREADY_EXIST("We already have a restaurant with that 'name'.");
+    NAME_ALREADY_EXIST("We already have a restaurant with that 'name'."),
+    OWNER_NOT_FOUND_OR_ROLED_INVALID("Owner not found or does not have the required role (PROPIETARIO).");
 
     private final String message;
 

--- a/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/application/exception/OwnerNotFoundOrInvalidRoleException.java
+++ b/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/application/exception/OwnerNotFoundOrInvalidRoleException.java
@@ -1,0 +1,7 @@
+package com.mycompany.app.microservice_restaurant_catalog.application.exception;
+
+public class OwnerNotFoundOrInvalidRoleException extends RuntimeException {
+    public OwnerNotFoundOrInvalidRoleException(String message) {
+        super(message);
+    }
+}

--- a/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/application/ports/out/TokenServicePort.java
+++ b/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/application/ports/out/TokenServicePort.java
@@ -2,20 +2,17 @@ package com.mycompany.app.microservice_restaurant_catalog.application.ports.out;
 
 import org.springframework.security.core.userdetails.UserDetails;
 
-<<<<<<< HEAD
+
 import java.util.List;
 
-=======
->>>>>>> 10352e266cac05aa46b170167b17643ccc591305
 public interface TokenServicePort {
 
     // Método para extraer el usuario desde el token
     String extractSubjectFromToken(String token);
 
-<<<<<<< HEAD
+
     List<String> extractRolesFromToken(String token);
-=======
->>>>>>> 10352e266cac05aa46b170167b17643ccc591305
+
 
 
 }

--- a/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/application/ports/out/UserValidationPort.java
+++ b/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/application/ports/out/UserValidationPort.java
@@ -1,0 +1,7 @@
+package com.mycompany.app.microservice_restaurant_catalog.application.ports.out;
+
+public interface UserValidationPort {
+
+    boolean isValidOwner(Long id);
+
+}

--- a/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/infrastructure/adapters/out/persistence/UserValidationAdapter.java
+++ b/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/infrastructure/adapters/out/persistence/UserValidationAdapter.java
@@ -9,12 +9,15 @@ import org.slf4j.Logger; // Para logging
 import org.slf4j.LoggerFactory;
 
 @Service
-@RequiredArgsConstructor
 public class UserValidationAdapter implements UserValidationPort {
 
     private static final Logger log = LoggerFactory.getLogger(UserValidationAdapter.class); // Logger
 
     private final UserFeignClient userFeignClient;
+
+    public UserValidationAdapter(UserFeignClient userFeignClient) {
+        this.userFeignClient = userFeignClient;
+    }
 
     @Override
     public boolean isValidOwner(Long id) {

--- a/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/infrastructure/adapters/out/persistence/UserValidationAdapter.java
+++ b/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/infrastructure/adapters/out/persistence/UserValidationAdapter.java
@@ -1,0 +1,41 @@
+package com.mycompany.app.microservice_restaurant_catalog.infrastructure.adapters.out.persistence;
+
+import com.mycompany.app.microservice_restaurant_catalog.application.ports.out.UserValidationPort;
+import com.mycompany.app.microservice_restaurant_catalog.infrastructure.feign.client.UserFeignClient;
+import com.mycompany.app.microservice_restaurant_catalog.infrastructure.feign.client.dto.OwnerValidationResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.slf4j.Logger; // Para logging
+import org.slf4j.LoggerFactory;
+
+@Service
+@RequiredArgsConstructor
+public class UserValidationAdapter implements UserValidationPort {
+
+    private static final Logger log = LoggerFactory.getLogger(UserValidationAdapter.class); // Logger
+
+    private final UserFeignClient userFeignClient;
+
+    @Override
+    public boolean isValidOwner(Long id) {
+
+        log.debug("Validando owner con el id: {} usando UserFeignClient", id);
+
+        try {
+            //Llamo al método definido en la interfaz Feign
+            // OpenFeign maneja la llamada HTTP real a microservice-user
+            OwnerValidationResponseDTO response = userFeignClient.validateOwner(id);
+            if(response != null){
+                log.debug("Recibido el OwnerValidationResponseDTO: {}", response.isValidOwner());
+                return response.isValidOwner();
+            }else{
+                log.warn("Received null response from UserFeignClient for ownerId: {}", id);
+                return false;
+            }
+        } catch (Exception e){
+            // Manejo de errores si la llamada Feign falla (ej. microservice-user caido, error de red, etc.)
+            log.error("Error callamdo UserFeignClient para validar User {}: {}", id, e.getMessage(), e);
+            return false;
+        }
+    }
+}

--- a/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/infrastructure/feign/client/UserFeignClient.java
+++ b/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/infrastructure/feign/client/UserFeignClient.java
@@ -1,0 +1,14 @@
+package com.mycompany.app.microservice_restaurant_catalog.infrastructure.feign.client;
+
+import com.mycompany.app.microservice_restaurant_catalog.infrastructure.feign.client.dto.OwnerValidationResponseDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "microservice-user")
+public interface UserFeignClient {
+
+    @GetMapping("/users/internal/validate-owner/{userId}")
+    OwnerValidationResponseDTO validateOwner(@PathVariable("userId") Long userId);
+
+}

--- a/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/infrastructure/feign/client/dto/OwnerValidationResponseDTO.java
+++ b/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/infrastructure/feign/client/dto/OwnerValidationResponseDTO.java
@@ -5,12 +5,18 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
-@Setter
+
 @AllArgsConstructor
 @NoArgsConstructor
 public class OwnerValidationResponseDTO {
 
     private boolean isValidOwner;
 
+    public boolean isValidOwner() {
+        return isValidOwner;
+    }
+
+    public void setValidOwner(boolean validOwner) {
+        isValidOwner = validOwner;
+    }
 }

--- a/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/infrastructure/feign/client/dto/OwnerValidationResponseDTO.java
+++ b/microservice-restaurant-catalog/src/main/java/com/mycompany/app/microservice_restaurant_catalog/infrastructure/feign/client/dto/OwnerValidationResponseDTO.java
@@ -1,0 +1,16 @@
+package com.mycompany.app.microservice_restaurant_catalog.infrastructure.feign.client.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OwnerValidationResponseDTO {
+
+    private boolean isValidOwner;
+
+}

--- a/microservice-user/src/main/java/com/microservice_user/application/DTOs/response/OwnerValidationResponseDTO.java
+++ b/microservice-user/src/main/java/com/microservice_user/application/DTOs/response/OwnerValidationResponseDTO.java
@@ -1,0 +1,16 @@
+package com.microservice_user.application.DTOs.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OwnerValidationResponseDTO {
+
+    private boolean isValidOwner;
+
+}

--- a/microservice-user/src/main/java/com/microservice_user/application/ports/in/ValidateOwnerRoleUseCase.java
+++ b/microservice-user/src/main/java/com/microservice_user/application/ports/in/ValidateOwnerRoleUseCase.java
@@ -1,0 +1,7 @@
+package com.microservice_user.application.ports.in;
+
+public interface ValidateOwnerRoleUseCase {
+
+    boolean validateRole(Long id);
+
+}

--- a/microservice-user/src/main/java/com/microservice_user/application/services/ValidateOwnerRoleService.java
+++ b/microservice-user/src/main/java/com/microservice_user/application/services/ValidateOwnerRoleService.java
@@ -1,0 +1,29 @@
+package com.microservice_user.application.services;
+
+import com.microservice_user.application.ports.in.ValidateOwnerRoleUseCase;
+import com.microservice_user.application.ports.out.UserRepositoryPort;
+import com.microservice_user.domain.User;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class ValidateOwnerRoleService implements ValidateOwnerRoleUseCase {
+
+    private final UserRepositoryPort userRepositoryPort;
+
+    public ValidateOwnerRoleService(UserRepositoryPort userRepositoryPort) {
+        this.userRepositoryPort = userRepositoryPort;
+    }
+
+    @Override
+    public boolean validateRole(Long id) {
+
+        Optional<User> userOptional = userRepositoryPort.findById(id);
+        if(userOptional.isEmpty()){
+            return false;
+        }
+        return userOptional.map(user -> user.getRole().name().equals("PROPIETARIO")).orElse(false);
+
+    }
+}

--- a/microservice-user/src/main/java/com/microservice_user/infrastructure/adapters/in/web/UserController.java
+++ b/microservice-user/src/main/java/com/microservice_user/infrastructure/adapters/in/web/UserController.java
@@ -2,6 +2,7 @@ package com.microservice_user.infrastructure.adapters.in.web;
 
 
 import com.microservice_user.application.DTOs.*;
+import com.microservice_user.application.DTOs.response.OwnerValidationResponseDTO;
 import com.microservice_user.application.ports.in.*;
 import com.microservice_user.domain.User;
 import jakarta.validation.Valid;
@@ -20,6 +21,7 @@ public class UserController {
     private final CreateOwnerUseCase createOwnerUseCase;
     private final LoginUseCase loginUseCase;
     private final AuthenticatedUserPort authenticatedUserPort;
+    private final ValidateOwnerRoleUseCase validateOwnerRoleUseCase;
 
     @PostMapping("/create-client")
     public ResponseEntity<User> createClient(@Valid @RequestBody CreateClientDTO clientDTO){
@@ -42,6 +44,16 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDTO> login(@Valid @RequestBody LoginRequestDTO loginRequestDTO){
         return ResponseEntity.ok(loginUseCase.login(loginRequestDTO));
+    }
+
+
+    //   --------- ENDPOINTS PARA COMUNICACIÓN ENTRE MICROSERVICIOS ----------
+    @GetMapping("/internal/validate-owner/{userId}")
+    public OwnerValidationResponseDTO validateOwner(@PathVariable("userId") Long id){
+        boolean result = validateOwnerRoleUseCase.validateRole(id);
+        OwnerValidationResponseDTO ownerValidationResponseDTO = new OwnerValidationResponseDTO();
+        ownerValidationResponseDTO.setValidOwner(result);
+        return ownerValidationResponseDTO;
     }
 
 

--- a/microservice-user/src/main/java/com/microservice_user/infrastructure/config/SecurityConfig.java
+++ b/microservice-user/src/main/java/com/microservice_user/infrastructure/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/users/create-owner").permitAll()
                         .requestMatchers(HttpMethod.POST, "/users/login").permitAll()
                         .requestMatchers(HttpMethod.GET, "/users/protected-test").hasRole(RoleEnum.CLIENTE.name())
-
+                        .requestMatchers(HttpMethod.GET, "/users/internal/validate-owner/**").permitAll()
                         .anyRequest().authenticated())
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())


### PR DESCRIPTION
Este PR implementa la **Tarea 3.12: Definición e Implementación de Puerto de Salida para Comunicación con User/Auth** del Sprint 3. El objetivo principal es permitir que `microservice-restaurant-catalog` valide si el `ownerId` proporcionado al crear un restaurante corresponde a un usuario válido con el rol PROPIETARIO que existe en `microservice-user`. Para esto, se estableció comunicación síncrona entre ambos microservicios utilizando Spring Cloud OpenFeign.

**Cambios Implementados:**

En **`microservice-restaurant-catalog`**:
- Se definió el Puerto de Salida `UserValidationPort` en la capa de Aplicación para abstraer la dependencia de validación de usuarios.
- Se creó el Adaptador `UserValidationAdapter` (ubicado en `infrastructure.adapters.out`) que implementa `UserValidationPort`.
- Dentro del Adaptador, se configuró y utilizó un cliente OpenFeign (`UserFeignClient` en `infrastructure.feign.client`) para realizar la llamada HTTP al `microservice-user`.
- Se copió la definición del DTO de respuesta (`OwnerValidationResponseDTO`) desde el microservicio de usuarios a `infrastructure.feign.client.dto` para que el cliente Feign pudiera deserializar la respuesta.
- Se habilitó la funcionalidad de clientes Feign en la clase principal (`@EnableFeignClients`).
- Se integró la llamada al `UserValidationPort` en el método `createRestaurant` del `RestaurantService` (capa de Aplicación). Ahora, el servicio valida el propietario antes de guardar el restaurante.
- Se creó la excepción `OwnerNotFoundOrInvalidRoleException` en `application.exception` para manejar los casos en que la validación falle.

En **`microservice-user`**:
- Se definió el Puerto de Entrada `ValidateOwnerRoleUseCase` en la capa de Aplicación para la funcionalidad de validar el rol de un usuario.
- Se implementó el Servicio `ValidateOwnerRoleService` (capa de Aplicación) que implementa el Use Case, utilizando el `UserRepositoryPort` para acceder a los datos de usuario. (Se corrigió la lógica para manejar `Optional` de forma segura y usar `equals()` para comparar el nombre del rol).
- Se definió el DTO `OwnerValidationResponseDTO` en `application.dtos.response.internal` para la respuesta de validación.
- Se implementó un nuevo endpoint REST en el controlador (`UserController`) en la ruta `GET /users/internal/validate-owner/{userId}`. Este endpoint llama al servicio de aplicación de usuarios para obtener el resultado de la validación y devuelve el `OwnerValidationResponseDTO`.
- Se modificó la configuración de seguridad (`SecurityConfig`) para permitir el acceso sin autenticación a este endpoint interno (`.requestMatchers(HttpMethod.GET, "/users/internal/validate-owner/**").permitAll()`) para permitir la comunicación entre servicios.

**Verificación:**

Se han realizado pruebas manuales exitosas que confirman el correcto funcionamiento del flujo:
- Al intentar crear un restaurante con un `ownerId` que corresponde a un usuario PROPIETARIO válido en `microservice-user`, la llamada Feign fue exitosa, la validación pasó, y el restaurante se creó (respuesta HTTP 201 Created).
- Al intentar crear un restaurante con un `ownerId` inválido (no existente o sin rol PROPIETARIO), la llamada Feign fue exitosa, la validación en `microservice-user` falló, el `RestaurantService` lanzó la `OwnerNotFoundOrInvalidRoleException`, la cual fue correctamente manejada por el `RestControllerAdvisor` (respuesta HTTP 400 Bad Request, según configuración), deteniendo la creación del restaurante.

Este PR completa la implementación de la validación del propietario y establece el patrón para futuras comunicaciones síncronas entre servicios en el proyecto utilizando OpenFeign y Service Discovery (Eureka).
